### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           gh release delete nightly --yes || true
 
       - name: Create nightly release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: refs/tags/${{ env.dev_tag }}
           name: Development build (master)
@@ -109,7 +109,7 @@ jobs:
           go-version: ${{ env.go_version }}
 
       - name: Create stable release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref }}
           name: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,9 +68,9 @@ jobs:
           prerelease: true
 
       - name: Build assets with Goreleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean --snapshot
 
       - name: Upload assets to nightly release
@@ -118,9 +118,9 @@ jobs:
           prerelease: false
 
       - name: Run Goreleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GORELEASER_GITHUB_TOKEN: ${{ secrets.SCOOP_BUCKET_GITHUB_TOKEN }}


### PR DESCRIPTION
- update goreleaser/goreleaser-action action to v6
  Use the new recommended `version: "~> v2"` input, see https://goreleaser.com/blog/goreleaser-v2/#github-action.
  https://github.com/goreleaser/goreleaser-action/releases/tag/v5.0.0
  https://github.com/goreleaser/goreleaser-action/releases/tag/v6.0.0
- update softprops/action-gh-release action to v2
  https://github.com/softprops/action-gh-release/releases/tag/v2.0.0

After the updates, the following job run warning should disappear.

> The following actions use a deprecated Node.js version and will be forced to run on node20: softprops/action-gh-release@v1, goreleaser/goreleaser-action@v4. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
> <sub>_see https://github.com/ayoisaiah/f2/actions/runs/10648955056_</sub>