### PR TITLE
Fix release name

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Create stable release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          name: ${{ github.ref }}
+          tag_name: ${{ github.event.client_payload.tag }}
+          name: ${{ github.event.client_payload.tag }}
           body: ${{ env.CHANGELOG }}
           draft: false
           prerelease: false
@@ -45,3 +45,4 @@ jobs:
           GORELEASER_GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           FURY_PUSH_TOKEN: ${{ secrets.FURY_PUSH_TOKEN }}
           FURY_USERNAME: ${{ secrets.FURY_USERNAME }}
+          GORELEASER_CURRENT_TAG: ${{ github.event.client_payload.name }}

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Create stable release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.client_payload.tag }}
-          name: ${{ github.event.client_payload.tag }}
+          tag_name: ${{ github.event.client_payload.tag_name }}
+          name: ${{ github.event.client_payload.tag_name }}
           body: ${{ env.CHANGELOG }}
           draft: false
           prerelease: false
@@ -45,4 +45,4 @@ jobs:
           GORELEASER_GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           FURY_PUSH_TOKEN: ${{ secrets.FURY_PUSH_TOKEN }}
           FURY_USERNAME: ${{ secrets.FURY_USERNAME }}
-          GORELEASER_CURRENT_TAG: ${{ github.event.client_payload.name }}
+          GORELEASER_CURRENT_TAG: ${{ github.event.client_payload.tag_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,4 +51,4 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.PERSONAL_ACCESS_TOKEN }}" \
             https://api.github.com/repos/ayoisaiah/f2/dispatches \
-            -d '{"event_type": "release_stable", "client_payload":{"tag": "${{ github.ref }}", "name": "${{ github.ref_name }}" }}'
+            -d '{"event_type": "release_stable", "client_payload":{"tag_name": "${{ github.ref_name }}"}}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,4 +51,4 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.PERSONAL_ACCESS_TOKEN }}" \
             https://api.github.com/repos/ayoisaiah/f2/dispatches \
-            -d '{"event_type": "release_stable"}'
+            -d '{"event_type": "release_stable", "client_payload":{"tag": "${{ github.ref }}", "name": "${{ github.ref_name }}" }}'


### PR DESCRIPTION
The [release for tag `v2.1.0`](https://github.com/ayoisaiah/f2/releases/tag/v2.1.0) was titled 'refs/tags/v2.1.0', which is wired and inconsistent with previous releases.

This PR fixes it.

------

`ayoisaiah/f2` has used
```yaml
        uses: actions/create-release@v1
        with:
          tag_name: ${{ github.ref }}
          name: ${{ github.ref }}
          # ...
```
since 8a50b63 (support for nightly releases, 2023-10-09), and it seemed to work well for releases made in Nov 2023.

Per the docs for [`softprops/action-gh-release` inputs](https://github.com/softprops/action-gh-release?tab=readme-ov-file#inputs)

Name | Type | Description
-- | -- | --
`name` | String | Name of the release. defaults to tag name
`tag_name` | String | Name of a tag. defaults to `github.ref_name`

both `name` and `tag_name` defaults to `github.ref_name`, aka the short name `vx.y.z`.

Not sure what has changed since then, but passing the short tag name to `name` and `tag_name` should fix the name of releases.