### PR TITLE
Improve date tokens in variables

### DIFF
--- a/replace/replace_test/variables_test.go
+++ b/replace/replace_test/variables_test.go
@@ -300,13 +300,13 @@ func TestVariables(t *testing.T) {
 				},
 			},
 			Want: []string{
-				"testdata/Nov-05-2019_2019-01-05T13:00:00+01:00_1546689600.txt",
+				"testdata/Nov-05-2019_1546689600.txt",
 			}, // date is set in TestMain
 			Args: []string{
 				"-f",
 				".*",
 				"-r",
-				"{atime.MMM}-{mtime.DD}-{mtime.YYYY}_{mtime}_{mtime.unix}{ext}",
+				"{atime.MMM}-{mtime.DD}-{mtime.YYYY}_{mtime.unix}{ext}",
 			},
 			SetupFunc: createDateFile,
 		},

--- a/replace/replace_test/variables_test.go
+++ b/replace/replace_test/variables_test.go
@@ -176,6 +176,24 @@ func TestVariables(t *testing.T) {
 			},
 		},
 		{
+			Name: "replace with Exif DateTimeOriginal in Unix time",
+			Changes: file.Changes{
+				{
+					BaseDir: "testdata",
+					Source:  "pic.jpg",
+				},
+				{
+					BaseDir: "testdata",
+					Source:  "image.dng",
+				},
+			},
+			Want: []string{
+				"testdata/990297401.jpg",
+				"testdata/1123095558.dng",
+			},
+			Args: []string{"-f", ".*", "-r", "{x.cdt.unix}{ext}"},
+		},
+		{
 			Name: "replace with Exif DateTimeOriginal",
 			Changes: file.Changes{
 				{
@@ -282,13 +300,13 @@ func TestVariables(t *testing.T) {
 				},
 			},
 			Want: []string{
-				"testdata/Nov-05-2019.txt",
+				"testdata/Nov-05-2019_2019-01-05T13:00:00+01:00_1546689600.txt",
 			}, // date is set in TestMain
 			Args: []string{
 				"-f",
 				".*",
 				"-r",
-				"{atime.MMM}-{mtime.DD}-{mtime.YYYY}{ext}",
+				"{atime.MMM}-{mtime.DD}-{mtime.YYYY}_{mtime}_{mtime.unix}{ext}",
 			},
 			SetupFunc: createDateFile,
 		},

--- a/replace/variables/variable_regex.go
+++ b/replace/variables/variable_regex.go
@@ -25,25 +25,27 @@ var (
 )
 
 var dateTokens = map[string]string{
-	"YYYY": "2006",
-	"YY":   "06",
-	"MMMM": "January",
-	"MMM":  "Jan",
-	"MM":   "01",
-	"M":    "1",
-	"DDDD": "Monday",
-	"DDD":  "Mon",
-	"DD":   "02",
-	"D":    "2",
-	"H":    "15",
-	"hh":   "03",
-	"h":    "3",
-	"mm":   "04",
-	"m":    "4",
-	"ss":   "05",
-	"s":    "5",
-	"A":    "PM",
-	"a":    "pm",
+	"YYYY":  "2006",
+	"YY":    "06",
+	"MMMM":  "January",
+	"MMM":   "Jan",
+	"MM":    "01",
+	"M":     "1",
+	"DDDD":  "Monday",
+	"DDD":   "Mon",
+	"DD":    "02",
+	"D":     "2",
+	"H":     "15",
+	"hh":    "03",
+	"h":     "3",
+	"mm":    "04",
+	"m":     "4",
+	"ss":    "05",
+	"s":     "5",
+	"A":     "PM",
+	"a":     "pm",
+	"unix":  "unix",
+	"since": "since",
 }
 
 func init() {
@@ -55,7 +57,7 @@ func init() {
 	tokenString := strings.Join(tokens, "|")
 
 	transformTokens = fmt.Sprintf(
-		"(up|lw|ti|win|mac|di|norm|(?:dt\\.(%s)))",
+		"(up|lw|ti|win|mac|di|norm|(?:dt(?:\\.(%s))?))",
 		tokenString,
 	)
 
@@ -98,7 +100,7 @@ func init() {
 
 	dateVarRegex = regexp.MustCompile(
 		fmt.Sprintf(
-			"{+("+timeutil.Mod+"|"+timeutil.Change+"|"+timeutil.Birth+"|"+timeutil.Access+"|"+timeutil.Current+")\\.("+tokenString+")(?:\\.%s)?}+",
+			"{+("+timeutil.Mod+"|"+timeutil.Change+"|"+timeutil.Birth+"|"+timeutil.Access+"|"+timeutil.Current+")(?:\\.("+tokenString+"))?(?:\\.%s)?}+",
 			transformTokens,
 		),
 	)


### PR DESCRIPTION
- date tokens are now optional
- add `since` token to get seconds since provided date
- add `unix` token to get unix time
- if token is not provided return RFC3339 representation of date